### PR TITLE
feat: Add global shortcuts toggle

### DIFF
--- a/src/app/_next/static/chunks/app/(product)/(app)/settings/page-25e819006c29fdd9.js
+++ b/src/app/_next/static/chunks/app/(product)/(app)/settings/page-25e819006c29fdd9.js
@@ -2267,6 +2267,23 @@
               );
             },
             [i],
+          ),
+          onToggleGlobalShortcuts = (0, d.useCallback)(
+            (e) => {
+              console.log("globalShortcuts.enable toggled. Value: ", e);
+              window.nativeSettings.set(
+                "modFeatures.globalShortcuts.enable",
+                e,
+              );
+              i(
+                (0, n.jsx)(p.Q, {
+                  error:
+                    "Для применения этой настройки требуется перезапуск приложения",
+                }),
+                { containerId: _.W$x.ERROR },
+              );
+            },
+            []
           );
         return (0, n.jsx)(f.u, {
           className: b().root,
@@ -2342,6 +2359,18 @@
                   onChange: onStartMinimizedToggle,
                   isChecked: window.nativeSettings.get(
                     "modFeatures.windowBehavior.startMinimized",
+                  ),
+                }),
+              }),
+              (0, n.jsx)("li", {
+                className: Z().item,
+                children: (0, n.jsx)(P, {
+                  title: "Глобальные горячие клавиши",
+                  description:
+                    "Включает поддержку глобальных горячих клавиш",
+                  onChange: onToggleGlobalShortcuts,
+                  isChecked: window.nativeSettings.get(
+                    "modFeatures.globalShortcuts.enable",
                   ),
                 }),
               }),

--- a/src/app/_next/static/chunks/app/(product)/(app)/settings/page-25e819006c29fdd9.js
+++ b/src/app/_next/static/chunks/app/(product)/(app)/settings/page-25e819006c29fdd9.js
@@ -2275,13 +2275,6 @@
                 "modFeatures.globalShortcuts.enable",
                 e,
               );
-              i(
-                (0, n.jsx)(p.Q, {
-                  error:
-                    "Для применения этой настройки требуется перезапуск приложения",
-                }),
-                { containerId: _.W$x.ERROR },
-              );
             },
             []
           );
@@ -2367,7 +2360,7 @@
                 children: (0, n.jsx)(P, {
                   title: "Глобальные горячие клавиши",
                   description:
-                    "Включает поддержку глобальных горячих клавиш",
+                    "Настроить комбинации можно в Настройки -> Остальные настройки",
                   onChange: onToggleGlobalShortcuts,
                   isChecked: window.nativeSettings.get(
                     "modFeatures.globalShortcuts.enable",

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -10,6 +10,7 @@ exports.sendRefreshRepositoryMeta =
   exports.sendLoadReleaseNotes =
   exports.sendProbabilityBucket =
   exports.handleApplicationEvents =
+  exports.sendNativeStoreUpdate =
     void 0;
 const electron_1 = require("electron");
 const events_js_1 = require("./types/events.js");
@@ -352,6 +353,16 @@ electron_1.ipcMain.handle(
 );
 
 exports.handleApplicationEvents = handleApplicationEvents;
+
+const sendNativeStoreUpdate = (key, value, window=undefined) => {
+    (window ?? mainWindow)?.webContents.send(events_js_1.Events.NATIVE_STORE_UPDATE, key, value);
+    if(window ?? mainWindow) {
+        eventsLogger.info("Event send", events_js_1.Events.NATIVE_STORE_UPDATE, key, value)
+    } else {
+        eventsLogger.warn("Event not send, window is undefined", events_js_1.Events.NATIVE_STORE_UPDATE, key, value)
+    }
+};
+exports.sendNativeStoreUpdate = sendNativeStoreUpdate;
 
 const sendLastFmUserInfoUpdated = (window = mainWindow, userinfo) => {
   window.webContents.send(events_js_1.Events.LASTFM_USERINFO_UPDATE, userinfo);

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -273,8 +273,8 @@ const handleApplicationEvents = (window) => {
     },
   );
 
-  electron_1.ipcMain.on(events_js_1.Events.NATIVE_STORE_UPDATE,(event, key, value) => {
-      eventsLogger.info(`Event received`, events_js_1.Events.NATIVE_STORE_UPDATE, key, value);
+  electron_1.ipcMain.on(events_js_1.Events.NATIVE_STORE_SET,(event, key, value) => {
+      eventsLogger.info(`Event received`, events_js_1.Events.NATIVE_STORE_SET, key, value);
         store_js_1.set(key, value);
         if (key === "modFeatures.globalShortcuts.enable") {
           updateGlobalShortcuts();

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -39,20 +39,21 @@ const isBoolean = (value) => {
 
 let mainWindow = undefined;
 
-const handleApplicationEvents = (window) => {
-  mainWindow = window;
-  const updater = (0, updater_js_1.getUpdater)();
-  const trackDownloader = new trackDownloader_js_1.TrackDownloader(window);
-  if (store_js_1.getModFeatures()?.globalShortcuts) {
-    const shortcuts = Object.entries(
-      store_js_1.getModFeatures().globalShortcuts,
-    );
+const updateGlobalShortcuts = () => {
+  electron_1.globalShortcut.unregisterAll();
+
+  const modFeatures = (0, store_js_1.getModFeatures)();
+
+  if (modFeatures?.globalShortcuts?.enable) {
+    const shortcuts = Object.entries(modFeatures.globalShortcuts);
     shortcuts.forEach((shortcut) => {
+      if (shortcut[0] === "enable") return;
+
       if (shortcut[1] && isAccelerator(shortcut[1])) {
         electron_1.globalShortcut.register(shortcut[1], () => {
           const actions = shortcut[0].split(" ");
           actions.forEach((action) => {
-            sendPlayerAction(window, playerActions_js_1.PlayerActions[action]);
+            sendPlayerAction(mainWindow, playerActions_js_1.PlayerActions[action]);
           });
         });
       } else {
@@ -61,7 +62,18 @@ const handleApplicationEvents = (window) => {
         );
       }
     });
+    eventsLogger.info("Global shortcuts registered.");
+  } else {
+    eventsLogger.info("Global shortcuts are disabled. Unregistered all.");
   }
+};
+
+const handleApplicationEvents = (window) => {
+  mainWindow = window;
+  const updater = (0, updater_js_1.getUpdater)();
+  const trackDownloader = new trackDownloader_js_1.TrackDownloader(window);
+  
+  updateGlobalShortcuts();
 
   electron_1.ipcMain.on(
     events_js_1.Events.DOWNLOAD_TRACK,

--- a/src/main/lib/preload.js
+++ b/src/main/lib/preload.js
@@ -133,7 +133,7 @@ electron_1.contextBridge.exposeInMainWorld("nativeSettings", {
     return store_js_1.get(key);
   },
   set(key, value) {
-    electron_1.ipcRenderer.send(events_js_1.Events.NATIVE_STORE_UPDATE, key, value);
+    electron_1.ipcRenderer.send(events_js_1.Events.NATIVE_STORE_SET, key, value);
   },
   setPathWithNativeDialog(
     key,

--- a/src/main/lib/preload.js
+++ b/src/main/lib/preload.js
@@ -7,6 +7,7 @@ const getInitialTheme_js_1 = require("./getInitialTheme.js");
 const deviceInfo_js_1 = require("./deviceInfo.js");
 const theme_js_1 = require("../types/theme.js");
 const hostnamePatterns_js_1 = require("../constants/hostnamePatterns.js");
+const events_js_1 = require('../types/events.js');
 const deviceInfo = (0, deviceInfo_js_1.getDeviceInfo)();
 
 electron_1.contextBridge.exposeInMainWorld(
@@ -132,7 +133,7 @@ electron_1.contextBridge.exposeInMainWorld("nativeSettings", {
     return store_js_1.get(key);
   },
   set(key, value) {
-    return store_js_1.set(key, value);
+    electron_1.ipcRenderer.send(events_js_1.Events.NATIVE_STORE_UPDATE, key, value);
   },
   setPathWithNativeDialog(
     key,

--- a/src/main/lib/store.js
+++ b/src/main/lib/store.js
@@ -113,6 +113,7 @@ const init = () => {
       preventDisplaySleep: false,
     },
     globalShortcuts: {
+      enable: true,
       TOGGLE_PLAY: "Ctrl+/",
       MOVE_FORWARD: "Ctrl+,",
       MOVE_BACKWARD: "Ctrl+.",

--- a/src/main/lib/store.js
+++ b/src/main/lib/store.js
@@ -21,6 +21,8 @@ exports.useCachedValue =
   exports.getDevtoolsEnabled =
   exports.getModFeatures =
   exports.init =
+  exports.set =
+  exports.get =
     void 0;
 const uuid_1 = require("uuid");
 const semver_1 = require("semver");
@@ -421,6 +423,8 @@ exports.get = getStore;
 const setStore = (key, value) => {
   const result = store.set(key, value);
   cachedStore.set(key, value);
+  const { sendNativeStoreUpdate } = require('../events.js');               // Import here to avoid circular dependency. Cons of using CommonJS.
+  sendNativeStoreUpdate(key, value);
   return result;
 };
 exports.set = setStore;

--- a/src/main/types/events.js
+++ b/src/main/types/events.js
@@ -31,4 +31,5 @@ var Events;
   Events["DOWNLOAD_TRACK"] = "DOWNLOAD_TRACK";
   Events["LASTFM_USERINFO_UPDATE"] = "LASTFM_USERINFO_UPDATE";
   Events["NATIVE_STORE_UPDATE"] = "NATIVE_STORE_UPDATE";
+  Events["NATIVE_STORE_SET"] = "NATIVE_STORE_SET";
 })(Events || (exports.Events = Events = {}));


### PR DESCRIPTION
В данной имплементации реализован тумблер для переключения регистрации глобальных горячих клавиш при запуске приложения. Данный тумблер добавлен в раздел мода "Системные настройки", так как, по моему мнению, данный раздел подходит лучше всего для внедрения одного тумблера без нагромождения отдельных вкладок. Чтобы лишний раз не прослушивать события, данная настройка требует перезапуска приложения. Также регистрация глобальных горячих клавиш вынесена в отдельную подраздельную функцию.